### PR TITLE
fix: when bind parameter is missing, returns 

### DIFF
--- a/src/Statement.cpp
+++ b/src/Statement.cpp
@@ -163,90 +163,112 @@ void Statement::bind(const int aIndex)
 void Statement::bind(const char* apName, const int aValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_int(mStmtPtr, index, aValue);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_int(mStmtPtr, index, aValue);
+        check(ret);
+    }
 }
 
 // Bind a 32bits unsigned int value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const char* apName, const unsigned aValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_int64(mStmtPtr, index, aValue);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_int64(mStmtPtr, index, aValue);
+        check(ret);
+    }
 }
 
 // Bind a 64bits int value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const char* apName, const long long aValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_int64(mStmtPtr, index, aValue);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_int64(mStmtPtr, index, aValue);
+        check(ret);
+    }
 }
 
 // Bind a double (64bits float) value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const char* apName, const double aValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_double(mStmtPtr, index, aValue);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_double(mStmtPtr, index, aValue);
+        check(ret);
+    }
 }
 
 // Bind a string value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const char* apName, const std::string& aValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_text(mStmtPtr, index, aValue.c_str(),
-                                      static_cast<int>(aValue.size()), SQLITE_TRANSIENT);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_text(mStmtPtr, index, aValue.c_str(),
+                                          static_cast<int>(aValue.size()), SQLITE_TRANSIENT);
+        check(ret);
+    }
 }
 
 // Bind a text value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const char* apName, const char* apValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_text(mStmtPtr, index, apValue, -1, SQLITE_TRANSIENT);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_text(mStmtPtr, index, apValue, -1, SQLITE_TRANSIENT);
+        check(ret);
+    }
 }
 
 // Bind a binary blob value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const char* apName, const void* apValue, const int aSize)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_blob(mStmtPtr, index, apValue, aSize, SQLITE_TRANSIENT);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_blob(mStmtPtr, index, apValue, aSize, SQLITE_TRANSIENT);
+        check(ret);
+    }
 }
 
 // Bind a string value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const char* apName, const std::string& aValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_text(mStmtPtr, index, aValue.c_str(),
-                                      static_cast<int>(aValue.size()), SQLITE_STATIC);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_text(mStmtPtr, index, aValue.c_str(),
+                                          static_cast<int>(aValue.size()), SQLITE_STATIC);
+        check(ret);
+    }
 }
 
 // Bind a text value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const char* apName, const char* apValue)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_text(mStmtPtr, index, apValue, -1, SQLITE_STATIC);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_text(mStmtPtr, index, apValue, -1, SQLITE_STATIC);
+        check(ret);
+    }
 }
 
 // Bind a binary blob value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bindNoCopy(const char* apName, const void* apValue, const int aSize)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_blob(mStmtPtr, index, apValue, aSize, SQLITE_STATIC);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_blob(mStmtPtr, index, apValue, aSize, SQLITE_STATIC);
+        check(ret);
+    }
 }
 
 // Bind a NULL value to a parameter "?NNN", ":VVV", "@VVV" or "$VVV" in the SQL prepared statement
 void Statement::bind(const char* apName)
 {
     const int index = sqlite3_bind_parameter_index(mStmtPtr, apName);
-    const int ret = sqlite3_bind_null(mStmtPtr, index);
-    check(ret);
+    if (index != 0) {
+        const int ret = sqlite3_bind_null(mStmtPtr, index);
+        check(ret);
+    }
 }
 
 


### PR DESCRIPTION
*  `sqlite3_bind_parameter_index`, function returns zero, if no matching parameter is found.
* in case query parameter is not used in the statement, this causes a ~crash~ exception in iOS.  `sqlite3_bind_xxx`, function was returning `SQLITE_RANGE`.
* fix is checking whether `index` is non zero before binding it. 